### PR TITLE
Update ProjectCommunityDetailSection: thêm 4 dự án mẫu với thông số và album riêng

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { HeroSection } from './sections/HeroSection';
 import { AboutSection } from './sections/AboutSection';
 import { CoreValuesSection } from './sections/CoreValuesSection';
@@ -5,12 +6,13 @@ import { MemberJourneySection } from './sections/MemberJourneySection';
 import { RegistrationFormSection } from './sections/RegistrationFormSection';
 import { ExploreCommunitiesSection } from './sections/ExploreCommunitiesSection';
 import { StorySection } from './sections/StorySection';
-import { CommunityLeadersSection } from './sections/CommunityLeadersSection';
 interface HomePageProps {
   onNavigate: (target: string, href?: string) => void;
 }
 
 export const HomePage = ({ onNavigate }: HomePageProps) => {
+  const [isFormOpen, setIsFormOpen] = useState(false);
+
   return (
     <div>
       <HeroSection />
@@ -18,8 +20,7 @@ export const HomePage = ({ onNavigate }: HomePageProps) => {
       <CoreValuesSection />
       <MemberJourneySection />
       <StorySection />
-      <CommunityLeadersSection />
-      <RegistrationFormSection />
+      <RegistrationFormSection open={isFormOpen} setOpen={setIsFormOpen} />
       <ExploreCommunitiesSection onNavigate={onNavigate} />
     </div>
   );


### PR DESCRIPTION
This task focuses on cleaning up the homepage by removing the "Community Leaders" section, as it is intended to be displayed only on the community page, not on the homepage.

Additionally, a fix was implemented for the `RegistrationFormSection` component, which was previously throwing a TypeScript error due to missing required props. The `open` and `setOpen` props were properly passed using React's `useState` hook to ensure the registration form works correctly.

Key changes:
- Removed `CommunityLeadersSection` from `HomePage.tsx` (both from the import and the render).
- Added `useState` to manage the form's open/close state.
- Fixed TypeScript error by correctly passing `open` and `setOpen` props to `RegistrationFormSection`.
- Ensured the homepage remains functional and error-free.
